### PR TITLE
Images Section

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [2.1.0] -
+
+* [#29] Added ability to add custom image to `MessageCard`. 
+
 ## [2.0.0] - 28th Feb 2021
 
 * [#14] Added ability to declare custom `MessageCard` actions via JSON string

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -4,10 +4,10 @@ default_step_lib_source: https://github.com/bitrise-io/bitrise-steplib.git
 app:
   envs:
     # An example secret param, define it (A_SECRET_PARAM) in .bitrise.secrets.yml
-    - STEP_VERSION: 2.0.0
+    - STEP_VERSION: 2.1.0
     # If you want to share this step into a StepLib
     - BITRISE_STEP_ID: microsoft-teams-integration
-    - BITRISE_STEP_VERSION: "2.0.0"
+    - BITRISE_STEP_VERSION: "2.1.0"
     - BITRISE_STEP_GIT_CLONE_URL: https://github.com/amrfarid140/bitrise-step-microsoft-teams-integration.git
     - MY_STEPLIB_REPO_FORK_GIT_URL: https://github.com/amrfarid140/bitrise-steplib.git
 

--- a/config.go
+++ b/config.go
@@ -25,6 +25,7 @@ type config struct {
 	SectionText                  string `env:"section_text"`
 	SectionHeaderImage           string `env:"section_header_image"`
 	SectionImage                 string `env:"section_image"`
+	SectionImageDescription      string `env:"section_image_description"`
 	EnablePrimarySectionMarkdown string `env:"enable_primary_section_markdown"`
 	EnableBuildFactsMarkdown     string `env:"enable_build_status_facts_markdown"`
 	EnableDefaultActions         string `env:"enable_default_actions"`

--- a/config.go
+++ b/config.go
@@ -24,6 +24,7 @@ type config struct {
 	SectionSubtitle              string `env:"section_subtitle"`
 	SectionText                  string `env:"section_text"`
 	SectionHeaderImage           string `env:"section_header_image"`
+	SectionImage                 string `env:"section_image"`
 	EnablePrimarySectionMarkdown string `env:"enable_primary_section_markdown"`
 	EnableBuildFactsMarkdown     string `env:"enable_build_status_facts_markdown"`
 	EnableDefaultActions         string `env:"enable_default_actions"`

--- a/main.go
+++ b/main.go
@@ -51,9 +51,9 @@ func newMessage(cfg config, buildSuccessful bool) Message {
 
 	// MessageCard sections
 	primarySection := buildPrimarySection(cfg)
-	factsSection := buildFactsSection(cfg, buildSuccessful)
 	imagesSection := buildImagesSection(cfg)
-	message.Sections = []Section{primarySection, factsSection, imagesSection}
+	factsSection := buildFactsSection(cfg, buildSuccessful)
+	message.Sections = []Section{primarySection, imagesSection, factsSection}
 
 	// MessageCard Actions
 	actions := []OpenURIAction{}
@@ -93,6 +93,19 @@ func buildPrimarySection(cfg config) Section {
 	section.Text = cfg.SectionText
 	section.ActivityImage = cfg.SectionHeaderImage
 	section.Markdown = valueOptionToBool(cfg.EnablePrimarySectionMarkdown)
+	return section
+}
+
+// Builds a Section containing a list of Image
+func buildImagesSection(cfg config) Section {
+	section := Section{}
+	if cfg.SectionImage != "" {
+		image := Image{
+			Image: cfg.SectionImage,
+			Title: cfg.SectionImageDescription,
+		}
+		section.Images = []Image{image}
+	}
 	return section
 }
 
@@ -137,17 +150,6 @@ func buildFactsSection(cfg config, buildSuccessful bool) Section {
 		Markdown: valueOptionToBool(cfg.EnableBuildFactsMarkdown),
 		Facts:    []Fact{buildStatusFact, buildNumberFact, buildBranchFact, buildTimeFact, workflowFact},
 	}
-}
-
-// Builds a Section containing a list of Image
-func buildImagesSection(cfg config) Section {
-	section := Section{}
-	image := Image{
-		Image: cfg.SectionImage,
-		Title: cfg.SectionImageDescription,
-	}
-	section.Images = []Image{image}
-	return section
 }
 
 func buildURIAction(action Action) OpenURIAction {

--- a/main.go
+++ b/main.go
@@ -142,7 +142,11 @@ func buildFactsSection(cfg config, buildSuccessful bool) Section {
 // Builds a Section containing a list of Image
 func buildImagesSection(cfg config) Section {
 	section := Section{}
-	section.Images = []Image{cfg.SectionImage}
+	image := Image{
+		Image: cfg.SectionImage,
+		Title: cfg.SectionImageDescription,
+	}
+	section.Images = []Image{image}
 	return section
 }
 

--- a/main.go
+++ b/main.go
@@ -52,7 +52,8 @@ func newMessage(cfg config, buildSuccessful bool) Message {
 	// MessageCard sections
 	primarySection := buildPrimarySection(cfg)
 	factsSection := buildFactsSection(cfg, buildSuccessful)
-	message.Sections = []Section{primarySection, factsSection}
+	imagesSection := buildImagesSection(cfg)
+	message.Sections = []Section{primarySection, factsSection, imagesSection}
 
 	// MessageCard Actions
 	actions := []OpenURIAction{}
@@ -136,6 +137,13 @@ func buildFactsSection(cfg config, buildSuccessful bool) Section {
 		Markdown: valueOptionToBool(cfg.EnableBuildFactsMarkdown),
 		Facts:    []Fact{buildStatusFact, buildNumberFact, buildBranchFact, buildTimeFact, workflowFact},
 	}
+}
+
+// Builds a Section containing a list of Image
+func buildImagesSection(cfg config) Section {
+	section := Section{}
+	section.Images = []Image{cfg.SectionImage}
+	return section
 }
 
 func buildURIAction(action Action) OpenURIAction {

--- a/main_test.go
+++ b/main_test.go
@@ -187,7 +187,45 @@ func TestBuildFactsSection(t *testing.T) {
 }
 
 func TestBuildImagesSection(t *testing.T) {
+	var defaultValuesConfig = config{
+		SectionImage:            "https://www.example.com/image.png",
+		SectionImageDescription: "This is the image description",
+	}
+	var emptyDescriptionConfig = config{
+		SectionImage: "https://www.example.com/image.png",
+	}
+	var tests = []struct {
+		input    config
+		expected Section
+	}{
+		{
+			defaultValuesConfig,
+			Section{
+				Images: []Image{
+					{
+						Image: defaultValuesConfig.SectionImage,
+						Title: defaultValuesConfig.SectionImageDescription,
+					},
+				},
+			},
+		},
+		{
+			emptyDescriptionConfig,
+			Section{
+				Images: []Image{
+					{
+						Image: emptyDescriptionConfig.SectionImage,
+					},
+				},
+			},
+		},
+	}
 
+	for _, test := range tests {
+		if output := buildImagesSection(test.input); !reflect.DeepEqual(output, test.expected) {
+			t.Errorf("Test failed: config input was %v, expected %v", test.input, test.expected)
+		}
+	}
 }
 
 func TestNewMessage(t *testing.T) {
@@ -216,7 +254,7 @@ func TestNewMessage(t *testing.T) {
 			},
 		},
 		Markdown:  valueOptionToBool(mockConfig.EnableBuildFactsMarkdown),
-		HeroImage: HeroImage{},
+		HeroImage: Image{},
 	}
 
 	var buildFailedFacts = Section{
@@ -243,7 +281,7 @@ func TestNewMessage(t *testing.T) {
 			},
 		},
 		Markdown:  valueOptionToBool(mockConfig.EnableBuildFactsMarkdown),
-		HeroImage: HeroImage{},
+		HeroImage: Image{},
 	}
 
 	var primarySection = Section{
@@ -252,7 +290,16 @@ func TestNewMessage(t *testing.T) {
 		ActivityImage:    mockConfig.SectionHeaderImage,
 		Markdown:         valueOptionToBool(mockConfig.EnablePrimarySectionMarkdown),
 		Text:             mockConfig.SectionText,
-		HeroImage:        HeroImage{},
+		HeroImage:        Image{},
+	}
+
+	var imagesSection = Section{
+		Images: []Image{
+			{
+				Image: mockConfig.SectionImage,
+				Title: mockConfig.SectionImageDescription,
+			},
+		},
 	}
 
 	var buildSuccessMessage = Message{
@@ -262,7 +309,7 @@ func TestNewMessage(t *testing.T) {
 		Title:      mockConfig.CardTitle,
 		Summary:    fmt.Sprintf("%v #%v succeeded", mockConfig.AppTitle, mockConfig.BuildNumber),
 		// Be mindful of list order
-		Sections: []Section{primarySection, buildSuccessFacts},
+		Sections: []Section{primarySection, buildSuccessFacts, imagesSection},
 		Actions: []OpenURIAction{
 			{
 				Type: "OpenUri",
@@ -312,7 +359,7 @@ func TestNewMessage(t *testing.T) {
 		Title:      mockConfig.CardTitle,
 		Summary:    fmt.Sprintf("%v #%v failed", mockConfig.AppTitle, mockConfig.BuildNumber),
 		// Be mindful of list order
-		Sections: []Section{primarySection, buildFailedFacts},
+		Sections: []Section{primarySection, buildFailedFacts, imagesSection},
 		Actions: []OpenURIAction{
 			{
 				Type: "OpenUri",

--- a/main_test.go
+++ b/main_test.go
@@ -194,6 +194,8 @@ func TestBuildImagesSection(t *testing.T) {
 	var emptyDescriptionConfig = config{
 		SectionImage: "https://www.example.com/image.png",
 	}
+	var emptyImageConfig = config{}
+
 	var tests = []struct {
 		input    config
 		expected Section
@@ -218,6 +220,10 @@ func TestBuildImagesSection(t *testing.T) {
 					},
 				},
 			},
+		},
+		{
+			emptyImageConfig,
+			Section{},
 		},
 	}
 

--- a/main_test.go
+++ b/main_test.go
@@ -26,7 +26,8 @@ var mockConfig = config{
 	SectionSubtitle:              "Commit message",
 	SectionText:                  "Commit message body",
 	SectionHeaderImage:           "",
-	SectionImage:                 "",
+	SectionImage:                 "https://www.example.com/image.png",
+	SectionImageDescription:      "A description of the image",
 	EnablePrimarySectionMarkdown: "no",
 	EnableBuildFactsMarkdown:     "no",
 	EnableDefaultActions:         "yes",
@@ -315,7 +316,7 @@ func TestNewMessage(t *testing.T) {
 		Title:      mockConfig.CardTitle,
 		Summary:    fmt.Sprintf("%v #%v succeeded", mockConfig.AppTitle, mockConfig.BuildNumber),
 		// Be mindful of list order
-		Sections: []Section{primarySection, buildSuccessFacts, imagesSection},
+		Sections: []Section{primarySection, imagesSection, buildSuccessFacts},
 		Actions: []OpenURIAction{
 			{
 				Type: "OpenUri",
@@ -365,7 +366,7 @@ func TestNewMessage(t *testing.T) {
 		Title:      mockConfig.CardTitle,
 		Summary:    fmt.Sprintf("%v #%v failed", mockConfig.AppTitle, mockConfig.BuildNumber),
 		// Be mindful of list order
-		Sections: []Section{primarySection, buildFailedFacts, imagesSection},
+		Sections: []Section{primarySection, imagesSection, buildFailedFacts},
 		Actions: []OpenURIAction{
 			{
 				Type: "OpenUri",

--- a/main_test.go
+++ b/main_test.go
@@ -26,6 +26,7 @@ var mockConfig = config{
 	SectionSubtitle:              "Commit message",
 	SectionText:                  "Commit message body",
 	SectionHeaderImage:           "",
+	SectionImage:                 "",
 	EnablePrimarySectionMarkdown: "no",
 	EnableBuildFactsMarkdown:     "no",
 	EnableDefaultActions:         "yes",
@@ -183,6 +184,10 @@ func TestBuildFactsSection(t *testing.T) {
 			t.Errorf("Test failed: config input was %v, expected %v", test.input, test.expected)
 		}
 	}
+}
+
+func TestBuildImagesSection(t *testing.T) {
+
 }
 
 func TestNewMessage(t *testing.T) {

--- a/message.go
+++ b/message.go
@@ -13,14 +13,14 @@ type Message struct {
 
 // Section to be shown in the message
 type Section struct {
-	ActivityTitle    string    `json:"activityTitle"`
-	ActivitySubtitle string    `json:"activitySubtitle"`
-	ActivityImage    string    `json:"activityImage"`
-	Facts            []Fact    `json:"facts"`
-	Markdown         bool      `json:"markdown"`
-	Text             string    `json:"text"`
-	HeroImage        Image     `json:"heroImage"`
-	Images           []Image   `json:"images"`
+	ActivityTitle    string  `json:"activityTitle"`
+	ActivitySubtitle string  `json:"activitySubtitle"`
+	ActivityImage    string  `json:"activityImage"`
+	Facts            []Fact  `json:"facts"`
+	Markdown         bool    `json:"markdown"`
+	Text             string  `json:"text"`
+	HeroImage        Image   `json:"heroImage"`
+	Images           []Image `json:"images"`
 }
 
 // Fact related to the message
@@ -42,7 +42,7 @@ type Target struct {
 	URI string `json:"uri"`
 }
 
-// Image that is displayed within the Images section
+// Image that is displayed either within the Images section or as a HeroImage.
 type Image struct {
 	Image string `json:"image"`
 	Title string `json:"title"`

--- a/message.go
+++ b/message.go
@@ -19,12 +19,8 @@ type Section struct {
 	Facts            []Fact    `json:"facts"`
 	Markdown         bool      `json:"markdown"`
 	Text             string    `json:"text"`
-	HeroImage        HeroImage `json:"heroImage"`
-}
-
-// HeroImage that is displayed within the Message
-type HeroImage struct {
-	Image string `json:"image"`
+	HeroImage        Image     `json:"heroImage"`
+	Images           []Image   `json:"images"`
 }
 
 // Fact related to the message
@@ -44,4 +40,10 @@ type OpenURIAction struct {
 type Target struct {
 	OS  string `json:"os"`
 	URI string `json:"uri"`
+}
+
+// Image that is displayed within the Images section
+type Image struct {
+	Image string `json:"image"`
+	Title string `json:"title"`
 }

--- a/step.yml
+++ b/step.yml
@@ -133,6 +133,12 @@ inputs:
       title: "Section Image"
       summary: "Image that is displayed within the MessageCard Section `activityImage`"
 
+  - section_image:
+      opts:
+        category: "MessageCard Image"
+        title: "Image"
+        summary: "Image that is displayed within the MessageCard Section `images`"
+
   - enable_default_actions: "yes"
     opts:
       category: "MessageCard Actions"

--- a/step.yml
+++ b/step.yml
@@ -139,6 +139,12 @@ inputs:
         title: "Image"
         summary: "Image that is displayed within the MessageCard Section `images`"
 
+  - section_image_description:
+      opts:
+        category: "MessageCard Image"
+        title: "Image Description"
+        summary: "A short description of the image. Typically, description is displayed in a tooltip as the user hovers their mouse over the image."
+
   - enable_default_actions: "yes"
     opts:
       category: "MessageCard Actions"


### PR DESCRIPTION
Resolves #29 

This PR adds support for adding an optional images section to the message card with support for a single image.

I've never written Go before and I'm not sure how to write/run tests so I'd appreciate some feedback on this.